### PR TITLE
Implement mount options support

### DIFF
--- a/deploy/kubernetes/sample_app/pv.yaml
+++ b/deploy/kubernetes/sample_app/pv.yaml
@@ -10,6 +10,8 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Recycle
   storageClassName: efs-sc
+  mountOptions:
+    - tls
   csi:
     driver: efs.csi.aws.com
     volumeHandle: fs-ff2a9557  

--- a/deploy/kubernetes/sample_app/storageclass.yaml
+++ b/deploy/kubernetes/sample_app/storageclass.yaml
@@ -3,3 +3,5 @@ apiVersion: storage.k8s.io/v1
 metadata:
   name: efs-sc
 provisioner: efs.csi.aws.com
+mountOptions:
+  - tls

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,11 @@ This driver is in alpha stage. Basic volume operations that are functional inclu
 ## Features
 Currently only static provisioning is supported. This means a AWS EFS filesystem needs to be created manually on AWS first. After that it could be mounted inside container as a volume using AWS EFS CSI Driver.
 
+### Encryption In Transit
+One of the advantages of using EFS is that it provides [encryption in transit](https://aws.amazon.com/blogs/aws/new-encryption-of-data-in-transit-for-amazon-efs/) support using TLS. Using encryption in transit, data will be encrypted during its transition over the network to EFS service. This provides extra layer of depth-in-depth for applications that requires higher secuity compliance.
+
+To enable encryption in transit, `tls` needs to be set at `NodePublishVolumeRequest.VolumeCapability.MountVolume` object's `MountFlags` fields. For example of using it in kuberentes, see persistence volume manifest in [Example](#kubernetes-example)
+
 # Kubernetes Example
 This example demos how to make a EFS filesystem mounted inside container using the driver. Before this, get yourself familiar with setting up kubernetes on AWS and [creating EFS filesystem](https://docs.aws.amazon.com/efs/latest/ug/getting-started.html). And when creating EFS filesystem, make sure it is accessible from kuberenetes cluster. This can be achieved by creating EFS filesystem inside the same VPC as kubernetes cluster or using VPC peering.
 
@@ -41,7 +46,7 @@ kubectl apply -f https://raw.githubusercontent.com/aws/aws-efs-csi-driver/master
 kubectl apply -f https://raw.githubusercontent.com/aws/aws-efs-csi-driver/master/deploy/kubernetes/node.yaml
 ```
 
-Edit the [persistence volume manifest file](../deploy/kubernetes/sample_app/pv.yaml):
+Edit the [persistence volume manifest file](../deploy/kubernetes/sample_app/pv.yaml) (note that encryption in transit is enabled using mount option):
 ```
 apiVersion: v1
 kind: PersistentVolume
@@ -55,6 +60,8 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Recycle
   storageClassName: efs-sc
+  mountOptions:
+    - tls
   csi:
     driver: efs.csi.aws.com
     volumeHandle: [FileSystemId] 


### PR DESCRIPTION
This enables [EFS encryption in transit](https://aws.amazon.com/blogs/aws/new-encryption-of-data-in-transit-for-amazon-efs/) using tls as mount option.

**Testing Done**

Tested on k8s v1.13 which has CSI mount option support implemented

Used PV:
```
apiVersion: v1
kind: PersistentVolume
metadata:
  name: efs-pv
spec:
  capacity:
    storage: 5Gi
  volumeMode: Filesystem
  accessModes:
    - ReadWriteOnce
  persistentVolumeReclaimPolicy: Recycle
  storageClassName: efs-sc
  mountOptions:
    - tls
  csi:
    driver: efs.csi.aws.com
    volumeHandle: fs-4af69aab  
```

Verified that tls mount option is set during mount in EFS driver log:

```
I0102 21:36:13.615038       1 node.go:43] NodePublishVolume: called with args volume_id:"fs-4af69aab" target_path:"/var/lib/kubelet/pods/6641820f-0ed6-11e9-820b-0ae1b2749708/volumes/kubernetes.io~csi/efs-pv/mount" volume_capability:<mount:<mount_flags:"tls" > access_mode:<mode:SINGLE_NODE_WRITER > >
I0102 21:36:13.615098       1 node.go:82] NodePublishVolume: creating dir /var/lib/kubelet/pods/6641820f-0ed6-11e9-820b-0ae1b2749708/volumes/kubernetes.io~csi/efs-pv/mount
I0102 21:36:13.615114       1 node.go:87] NodePublishVolume: mounting fs-4af69aab:/ at /var/lib/kubelet/pods/6641820f-0ed6-11e9-820b-0ae1b2749708/volumes/kubernetes.io~csi/efs-pv/mount with options [tls]
```

And data is written onto EFS with no issue:

```
>>  kubectl exec -ti app -- tail -f /data/out.txt                                                                                                                               
Wed Jan 2 21:41:36 UTC 2019
Wed Jan 2 21:41:41 UTC 2019
Wed Jan 2 21:41:46 UTC 2019
Wed Jan 2 21:41:51 UTC 2019
Wed Jan 2 21:41:56 UTC 2019
Wed Jan 2 21:42:01 UTC 2019
```